### PR TITLE
Enable logging for incoming server requests

### DIFF
--- a/src/UMBridge.jl
+++ b/src/UMBridge.jl
@@ -374,7 +374,7 @@ function with_logging(handler, log::Bool=false, callName::String="handler")
   end
 end
 
-function serve_models(models::Vector, port=4242, max_workers=1)
+function serve_models(models::Vector, port=4242, logging::Bool=false, max_workers=1)
     # @TODO: Different argument for "Evaluate" to prevent extra verbosity?
     
     router = HTTP.Router()

--- a/src/UMBridge.jl
+++ b/src/UMBridge.jl
@@ -359,17 +359,34 @@ function applyHessianRequest(models::Vector)
     return handler
 end
 
+function with_logging(handler, log::Bool=false, callName::String="handler")
+  # @TODO: redirect logging to file object instead.
+  return function(req::HTTP.Request)
+    if log
+        println(">> Incoming Request: ", callName,   
+                "\tRequest information", String(copy(req.body)), "\n",
+                "[Header Info: ", req.headers, "]\n"
+                #"[host: ", req.headers["Host"],", length: ", req.headers["Content-Length"],
+                #", type: ", req.headers["Content-Type"], "agent: ", req.headers["User-Agent"], "]\n"
+        )
+    end
+    handler(req)  # Call the original handler
+  end
+end
+
 function serve_models(models::Vector, port=4242, max_workers=1)
+    # @TODO: Different argument for "Evaluate" to prevent extra verbosity?
+    
     router = HTTP.Router()
-    HTTP.register!(router, "POST", "/InputSizes", inputRequest(models))
-    HTTP.register!(router, "POST", "/OutputSizes", outputRequest(models))
-    HTTP.register!(router, "GET", "/Info", infoRequest(models))
-    HTTP.register!(router, "POST", "/ModelInfo", modelinfoRequest(models))
-    HTTP.register!(router, "POST", "/Evaluate", evaluateRequest(models))
-    HTTP.register!(router, "POST", "/Gradient", gradientRequest(models))
-    HTTP.register!(router, "POST", "/ApplyJacobian", applyJacobianRequest(models))
-    HTTP.register!(router, "POST", "/ApplyHessian", applyHessianRequest(models))
-    server = HTTP.serve!(router, port)
+    HTTP.register!(router, "POST", "/InputSizes", with_logging(inputRequest(models), logging, "InputSizes"))
+    HTTP.register!(router, "POST", "/OutputSizes", with_logging(outputRequest(models), logging, "OutputSizes"))
+    HTTP.register!(router, "GET", "/Info", with_logging(infoRequest(models), logging, "Info"))
+    HTTP.register!(router, "POST", "/ModelInfo", with_logging(modelinfoRequest(models), logging, "ModelInfo"))
+    HTTP.register!(router, "POST", "/Evaluate", with_logging(evaluateRequest(models), logging, "Evaluate"))
+    HTTP.register!(router, "POST", "/Gradient", with_logging(gradientRequest(models), logging, "Gradient"))
+    HTTP.register!(router, "POST", "/ApplyJacobian", with_logging(applyJacobianRequest(models), logging, "ApplyJacobian"))
+    HTTP.register!(router, "POST", "/ApplyHessian", with_logging(applyHessianRequest(models), logging, "ApplyHessian"))
+    server = HTTP.serve(router, port)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using HTTP
 using JSON
 using Test
 
+const port = 5252
+
 function testmodel_supported_operations(model)
     all([
         UMBridge.supports_evaluate(model),
@@ -14,7 +16,7 @@ end
 
 function testserver(models)
     # Serve model
-    port = 4242
+    # port = port
     server = UMBridge.serve_models(models, port)
     # Shut down server
     close(server)
@@ -22,7 +24,7 @@ function testserver(models)
 end
 
 function testclientserverpair(models, httpmodel)
-    server = UMBridge.serve_models(models, 4242)
+    server = UMBridge.serve_models(models, port)
     input = UMBridge.model_input_sizes(httpmodel)[1] == 1
     output = UMBridge.model_output_sizes(httpmodel)[1] == 1
     close(server)


### PR DESCRIPTION
Same as #14 (closed) without duplicate commits.

The server now prints out incoming requests with some associated metadata
Function call changed to: `UMBridge.serve_models([testmodel], 5232, true)` with the last `Bool` argument acting as a trigger to initiate logging (default argument is `false`).

As of now, there's an extra level of verbosity with all `Evaluate` calls being printed out -> a possible resolution could be to export the logs to file instead.  `tail -f <filename> | grep "keywords"` can then be used to filter for incoming requests.  OR use a separate argument to enalbe logging for evaluate all together? 

The two TODO's mentioned in `with_logging`, and `serve_models` refer to which of the two approach would be preferred.