### PR TITLE
Make input and output sizes config dependent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,16 @@
 name = "UMBridge"
 uuid = "0ac74fe0-b753-4e62-be71-04a8383fbbef"
-authors = ["UM-Bridge Team"]
 version = "1.1.7"
+authors = ["UM-Bridge Team"]
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 HTTP = "1.0, 1.1, 1.2"
 JSON = "0.21"
-Parameters = "0.12"
 julia = "1"
 
 [extras]

--- a/src/UMBridge.jl
+++ b/src/UMBridge.jl
@@ -179,18 +179,45 @@ function supports_apply_hessian(model::HTTPModel)
 	return parsed["support"]["ApplyHessian"]
 end
 
-@with_kw mutable struct Model
+mutable struct Model
 	name::String
-	inputSizes::AbstractArray
-	outputSizes::AbstractArray
-	supportsEvaluate::Bool = true
-	supportsGradient::Bool = false
-	supportsJacobian::Bool = false
-	supportsHessian::Bool  = false
-	evaluate::Function = (input::Any, config::Any) -> (error("Evaluate: Not implemented"))
-	gradient::Function = (outWrt::Any, inWrt::Any, input::Any, sens::Any, config::Any) -> (error("Gradient: Not implemented"))
-	applyJacobian::Function = (outWrt::Any, inWrt::Any, input::Any, vec::Any, config::Any) -> (error("Apply Jacobian: Not implemented"))
+    inputSizes::Function
+    outputSizes::Function
+    supportsEvaluate::Bool
+    supportsGradient::Bool
+    supportsJacobian::Bool
+    supportsHessian::Bool
+    evaluate::Function
+    gradient::Function
+    applyJacobian::Function
+    applyHessian::Function
+end
+
+function Model(;
+        name::String,
+        inputSizes::Union{Function,Vector{T}} = (config::Any) -> (error("inputSizes: Not implemented")),
+        outputSizes::Union{Function,Vector{T}} = (config::Any) -> (error("outputSizes: Not implemented")),
+        supportsEvaluate::Bool = true,
+        supportsGradient::Bool = false,
+        supportsJacobian::Bool = false,
+        supportsHessian::Bool = false,
+        evaluate::Function = (input::Any, config::Any) -> (error("Evaluate: Not implemented")),
+        gradient::Function = (outWrt::Any, inWrt::Any, input::Any, sens::Any, config::Any) -> (error("Gradient: Not implemented")),
+        applyJacobian::Function = (outWrt::Any, inWrt::Any, input::Any, vec::Any, config::Any) -> (error("Apply Jacobian: Not implemented")),
 	applyHessian::Function = (outWrt::Any, inWrt1::Any, inWrt2::Any, input::Any, sens::Any, vec::Any, config::Any) -> (error("Apply Hessian: Not implemented"))
+    ) where T
+
+    inputSizesArg = inputSizes
+    if typeof(inputSizes) <: Vector
+        inputSizesArg = (config::Any=Dict()) -> (return inputSizes)
+    end
+
+    outputSizesArg = outputSizes
+    if typeof(outputSizes) <: Vector
+        outputSizesArg = (config::Any=Dict()) -> (return outputSizes)
+    end
+
+    return Model(name, inputSizesArg, outputSizesArg, supportsEvaluate, supportsGradient, supportsJacobian, supportsHessian, evaluate, gradient, applyJacobian, applyHessian)
 end
 
 name(model::Model) = model.name
@@ -281,7 +308,7 @@ function inputRequest(models::Vector)
 
 		try
 			body = Dict(
-				    "inputSizes" => model.inputSizes
+                "inputSizes" => model.inputSizes(model_config)
 				    )
 			return HTTP.Response(JSON.json(body))
 		catch e
@@ -320,7 +347,7 @@ function outputRequest(models::Vector)
 
 		try
 			body = Dict(
-				    "outputSizes" => model.outputSizes
+                "outputSizes" => model.outputSizes(model_config)
 				    )
 			return HTTP.Response(JSON.json(body))
 		catch e
@@ -394,7 +421,7 @@ function evaluateRequest(models::Vector)
 		# Extract inputs and check
 		model_parameters = parsed_body["input"]
 		try
-			if length(model_parameters) != length(model.inputSizes)
+            if length(model_parameters) != length(model.inputSizes(model_config))
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -409,7 +436,7 @@ function evaluateRequest(models::Vector)
 
 		for i in 1:length(model_parameters)
 			try
-				if length(model_parameters[i]) != model.inputSizes[i]
+                if length(model_parameters[i]) != model.inputSizes(model_config)[i]
 
 					body = Dict(
 						    "error" => Dict(
@@ -444,7 +471,7 @@ function evaluateRequest(models::Vector)
 					    )
 				return HTTP.Response(400, JSON.json(body))
 			end
-			if length(model_parameters[i]) != model.inputSizes[i]
+            if length(model_parameters[i]) != model.inputSizes(model_config)[i]
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -472,7 +499,7 @@ function evaluateRequest(models::Vector)
 
 		# Validate output length
 		try
-			if length(output) != length(model.outputSizes)
+            if length(output) != length(model.outputSizes(model_config))
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidOutput",
@@ -495,7 +522,7 @@ function evaluateRequest(models::Vector)
 					    )
 				return HTTP.Response(400, JSON.json(body))
 			end
-			if length(output[i]) != model.outputSizes[i]
+            if length(output[i]) != model.outputSizes(model_config)[i]
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidOutput",
@@ -546,7 +573,7 @@ function gradientRequest(models::Vector)
 
 		model_inWrt = parsed_body["inWrt"] + 1 # account for julia indices starting at 1
 		try
-			if model_inWrt < 1 || model_inWrt > length(model.inputSizes)
+            if model_inWrt < 1 || model_inWrt > length(model.inputSizes(model_config))
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -560,7 +587,7 @@ function gradientRequest(models::Vector)
 		end             
 		model_outWrt = parsed_body["outWrt"] + 1 # account for julia indices starting at 1
 		try
-			if model_outWrt < 1 || model_outWrt > length(model.inputSizes)
+            if model_outWrt < 1 || model_outWrt > length(model.inputSizes(model_config))
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -576,7 +603,7 @@ function gradientRequest(models::Vector)
 		model_sens = parsed_body["sens"]
 		model_parameters = parsed_body["input"]
 		try
-			if length(model_parameters) != length(model.inputSizes)
+            if length(model_parameters) != length(model.inputSizes(model_config))
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -601,7 +628,7 @@ function gradientRequest(models::Vector)
 					return HTTP.Response(400, JSON.json(body))
 				end
 
-				if length(model_parameters[i]) != model.inputSizes[i]
+                if length(model_parameters[i]) != model.inputSizes(model_config)[i]
 					body = Dict(
 						    "error" => Dict(
 								    "type" => "InvalidInput",
@@ -670,7 +697,7 @@ function applyJacobianRequest(models::Vector)
 		model_vec = parsed_body["vec"]
 		model_parameters = parsed_body["input"]
 
-		if length(model_parameters) != length(model.inputSizes)
+        if length(model_parameters) != length(model.inputSizes(model_config))
 			body = Dict(
 				    "error" => Dict(
 						    "type" => "InvalidInput",
@@ -690,7 +717,7 @@ function applyJacobianRequest(models::Vector)
 					    )
 				return HTTP.Response(400, JSON.json(body))
 			end
-			if length(model_parameters[i]) != model.inputSizes[i]
+            if length(model_parameters[i]) != model.inputSizes(model_config)[i]
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",
@@ -758,7 +785,7 @@ function applyHessianRequest(models::Vector)
 		model_vec = parsed_body["vec"]
 		model_parameters = parsed_body["input"]
 
-		if length(model_parameters) != length(model.inputSizes)
+        if length(model_parameters) != length(model.inputSizes(model_config))
 			body = Dict(
 				    "error" => Dict(
 						    "type" => "InvalidInput",
@@ -778,7 +805,7 @@ function applyHessianRequest(models::Vector)
 					    )
 				return HTTP.Response(400, JSON.json(body))
 			end
-			if length(model_parameters[i]) != model.inputSizes[i]
+            if length(model_parameters[i]) != model.inputSizes(model_config)[i]
 				body = Dict(
 					    "error" => Dict(
 							    "type" => "InvalidInput",

--- a/src/UMBridge.jl
+++ b/src/UMBridge.jl
@@ -3,7 +3,6 @@ module UMBridge
 import HTTP
 import JSON
 import Base.Threads
-using Parameters
 using Sockets
 
 # Make HTTP request following UM-Bridge protocol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,71 @@ end
 
 end
 
+function testserver_varsizes(models,config)
+    body = Dict(
+        "name" => UMBridge.name(models[1]),
+        "config" => config
+    )
+
+    response_input = UMBridge.inputRequest(models)(HTTP.Request("POST","/InputSizes",[],JSON.json(body)))
+    response_output = UMBridge.outputRequest(models)(HTTP.Request("POST","/OutputSizes",[],JSON.json(body)))
+    parsed_input = JSON.parse(String(response_input.body))
+    parsed_output = JSON.parse(String(response_output.body))
+    return [response_input.status,response_output.status],[parsed_input["inputSizes"],parsed_output["outputSizes"]]
+end
+
+@testset "Variable sizes" begin
+    function infun(config)
+        if haskey(config,"biginput")
+            if config["biginput"]
+                return [10]
+            end
+        end
+        return [1]
+    end
+    function outfun(config)
+        if haskey(config,"bigoutput")
+            if config["bigoutput"]
+                return [5]
+            end
+        end
+        return [2]
+    end
+    modelVarIO = UMBridge.Model(
+        name = "varIO",
+        inputSizes = infun,
+        outputSizes = outfun,
+    )
+
+    # config given? In: false, out: false
+    status_ff,responses_ff = testserver_varsizes([modelVarIO],Dict())
+    @test status_ff[1] == 200
+    @test status_ff[2] == 200
+    @test responses_ff[1][1] == 1
+    @test responses_ff[2][1] == 2
+
+    # config given? In: true, out: false
+    status_tf,responses_tf = testserver_varsizes([modelVarIO],Dict("biginput"=>true))
+    @test status_tf[1] == 200
+    @test status_tf[2] == 200
+    @test responses_tf[1][1] == 10
+    @test responses_tf[2][1] == 2
+
+    # config given? In: false, out: true
+    status_ft,responses_ft = testserver_varsizes([modelVarIO],Dict("bigoutput"=>true))
+    @test status_ft[1] == 200
+    @test status_ft[2] == 200
+    @test responses_ft[1][1] == 1
+    @test responses_ft[2][1] == 5
+
+    # config given? In: true, out: true
+    status_tt,responses_tt = testserver_varsizes([modelVarIO],Dict("biginput"=>true,"bigoutput"=>true))
+    @test status_tt[1] == 200
+    @test status_tt[2] == 200
+    @test responses_tt[1][1] == 10
+    @test responses_tt[2][1] == 5
+end
+
 @testset "Test Connection" begin
     
     model=UMBridge.HTTPModel("posterior", "https://benchmark-analytic-funnel.linusseelinger.de")


### PR DESCRIPTION
This adds the functionality to have config dependent input and output sizes like in the Python version.

This is achieved through replacing the `@with_kw` with a proper outer constructor,
which allows for the sizes keyword arguments to be `Union{Function,Vector{T}}`
If, like previously, a fixed vector is passed it is used as return valued for the internal in/outputSizes function. 
This makes the change backwards compatible and non-breaking.

Additionally, I added some tests to ensure that passing the correct config will change the returned values.

@moriniandre this is the feature we were missing so far, so once this is release we could have the input parameters for the FE solver dependent on the material model.
@annereinarz FYI, I think you and Andrea briefly discussed this.
  